### PR TITLE
Update variable names to be consistent

### DIFF
--- a/airflow/providers/google/cloud/hooks/datapipeline.py
+++ b/airflow/providers/google/cloud/hooks/datapipeline.py
@@ -94,7 +94,7 @@ class DataPipelineHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def run_data_pipeline(
         self,
-        pipeline_id: str,
+        data_pipeline_name: str,
         project_id: str,
         location: str = DEFAULT_DATAPIPELINE_LOCATION,
     ) -> None:
@@ -106,7 +106,7 @@ class DataPipelineHook(GoogleBaseHook):
         print(dir(service.projects().locations()))
         request = (
             service.projects().locations().pipelines().run(
-                name = f"{parent}/pipelines/{pipeline_id}",
+                name = f"{parent}/pipelines/{data_pipeline_name}",
                 body = {},
             )
         )

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -99,7 +99,7 @@ class RunDataPipelineOperator(GoogleCloudBaseOperator):
         self.data_pipeline_hook = DataPipelineHook(gcp_conn_id=self.gcp_conn_id)
         
         self.response = self.data_pipeline_hook.run_data_pipeline(
-            pipeline_id = self.data_pipeline_name,
+            data_pipeline_name = self.data_pipeline_name,
             project_id = self.project_id,
             location = self.location
         )


### PR DESCRIPTION
CreateDataPipelineOperator uses variable name "data_pipeline_name" for the Data Pipeline name, whereas RunDataPipelineOperator uses variable name "pipeline_id" for the same value. Change to use the same variable name, "data_pipeline_name" to be more consistent and prevent confusion.