### PR TITLE
Update Run Operator to accept a response body dict and run the pipeline attached

### DIFF
--- a/airflow/example_dags/google-datapipeline.py
+++ b/airflow/example_dags/google-datapipeline.py
@@ -76,6 +76,7 @@ with models.DAG(
             }
         }
     )
+    run_data_pipeline = RunDataPipelineOperator(pipeline_name = create_data_pipeline["name"])
  
 
     create_data_pipeline 

--- a/airflow/example_dags/google-datapipeline.py
+++ b/airflow/example_dags/google-datapipeline.py
@@ -79,5 +79,4 @@ with models.DAG(
     run_data_pipeline = RunDataPipelineOperator(pipeline_name = create_data_pipeline["name"])
  
 
-    create_data_pipeline 
-    # >> run_data_pipeline
+    create_data_pipeline >> run_data_pipeline

--- a/airflow/providers/google/cloud/hooks/datapipeline.py
+++ b/airflow/providers/google/cloud/hooks/datapipeline.py
@@ -95,7 +95,7 @@ class DataPipelineHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def run_data_pipeline(
         self,
-        pipeline_name: str,
+        data_pipeline_name: str,
     ) -> None:
         """
         Runs DataPipeline.
@@ -104,7 +104,7 @@ class DataPipelineHook(GoogleBaseHook):
         print(dir(service.projects().locations()))
         request = (
             service.projects().locations().pipelines().run(
-                name = pipeline_name,
+                name = data_pipeline_name,
                 body = {},
             )
         )

--- a/airflow/providers/google/cloud/hooks/datapipeline.py
+++ b/airflow/providers/google/cloud/hooks/datapipeline.py
@@ -95,19 +95,16 @@ class DataPipelineHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def run_data_pipeline(
         self,
-        pipeline_id: str,
-        project_id: str,
-        location: str = DEFAULT_DATAPIPELINE_LOCATION,
+        pipeline_name: str,
     ) -> None:
         """
         Runs DataPipeline.
         """
-        parent = self.build_parent_name(project_id, location)
         service = self.get_conn()
         print(dir(service.projects().locations()))
         request = (
             service.projects().locations().pipelines().run(
-                name = f"{parent}/pipelines/{pipeline_id}",
+                name = pipeline_name,
                 body = {},
             )
         )

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -81,27 +81,21 @@ class RunDataPipelineOperator(GoogleCloudBaseOperator):
     """ Run Data Pipeline Operator """
     def __init__(
             self,
-            data_pipeline_name: str = "{{task.task_id}}",
-            project_id: str | None = None,
-            location: str = DEFAULT_DATAPIPELINE_LOCATION,
+            response_body: dict,
             gcp_conn_id: str = "google_cloud_default",
             **kwargs
     ) -> None:
         super().init(**kwargs)
 
-        self.project_id = project_id
-        self.location = location
-        self.data_pipeline_name = data_pipeline_name
-        self.gcp_conn_id = gcp_conn_id
-        self.data_pipeline_hook: DataPipelineHook | None = None
+        self.response_body = response_body
+        self.gcp_conn_id =  gcp_conn_id
+        self.pipeline_name = response_body["name"]
 
     def execute(self, context: Context):
         self.data_pipeline_hook = DataPipelineHook(gcp_conn_id=self.gcp_conn_id)
         
         self.response = self.data_pipeline_hook.run_data_pipeline(
-            pipeline_id = self.data_pipeline_name,
-            project_id = self.project_id,
-            location = self.location
+            pipeline_name = self.pipeline_name
         )
 
         return self.response

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -74,28 +74,27 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
         )
 
         # returns the full response body
-        return self.data_pipeline
+        return self.data_pipeline["name"]
 
 
 class RunDataPipelineOperator(GoogleCloudBaseOperator):
     """ Run Data Pipeline Operator """
     def __init__(
             self,
-            response_body: dict,
+            data_pipeline_name: str,
             gcp_conn_id: str = "google_cloud_default",
             **kwargs
     ) -> None:
         super().init(**kwargs)
 
-        self.response_body = response_body
+        self.data_pipeline_name = data_pipeline_name
         self.gcp_conn_id =  gcp_conn_id
-        self.pipeline_name = response_body["name"]
 
     def execute(self, context: Context):
         self.data_pipeline_hook = DataPipelineHook(gcp_conn_id=self.gcp_conn_id)
         
         self.response = self.data_pipeline_hook.run_data_pipeline(
-            pipeline_name = self.pipeline_name
+            data_pipeline_name = self.data_pipeline_name
         )
 
         return self.response


### PR DESCRIPTION
…commended that the run operator accept the entire response body.

Updated the Run Operator to accept the response body dict and removed the other parameters because they were used to build the pipeline name, which the response body includes. Created variable for the pipeline name that takes it from the given response body. Used it to call upon the hook. Updated the hook to accept the pipeline name and removed the building of the name. Added run_data_pipeline to example dags to call the Run Data Pipeline operator passing a pipeline name taken from the create_data_pipeline result. (which should be a response dict).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
