### PR TITLE
Change created pipeline source to airflow in CreateDataPipelineOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -60,8 +60,7 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
         self.data_pipeline_name = data_pipeline_name
         self.gcp_conn_id = gcp_conn_id
         self.datapipeline_hook : DataPipelineHook | None = None
-
-        self.body["pipelineSources"] = {"airflow"}
+        self.body["pipelineSources"] = {"airflow":"airflow"}
 
     def execute(self, context: Context):
         self.datapipeline_hook = DataPipelineHook(

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -61,6 +61,8 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.datapipeline_hook : DataPipelineHook | None = None
 
+        self.body["pipelineSources"] = {"airflow"}
+
     def execute(self, context: Context):
         self.datapipeline_hook = DataPipelineHook(
             gcp_conn_id=self.gcp_conn_id


### PR DESCRIPTION
All pipelines created by the CreateDataPipelineOperator will be coming from Airflow, so it can be hard-coded in the pipelineSources within the pipeline body.