### PR TITLE
Re: xianhualiu, Raise exception if Create or Run operator results in an error

### DIFF
--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -82,7 +82,7 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
         )
         self.log.info("Response Body: ", self.data_pipeline)
 
-        if "error" in self.response:
+        if "error" in self.data_pipeline:
             raise AirflowException(
                 print(self.data_pipeline.get("error").get("message"))
             )

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -84,7 +84,7 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
 
         if "error" in self.data_pipeline:
             raise AirflowException(
-                print(self.data_pipeline.get("error").get("message"))
+                self.data_pipeline.get("error").get("message")
             )
 
         # returns the full response body
@@ -143,7 +143,7 @@ class RunDataPipelineOperator(GoogleCloudBaseOperator):
 
         if "error" in self.response:
             raise AirflowException(
-                print(self.response.get("error").get("message"))
+                self.response.get("error").get("message")
             )
 
         return self.response

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -82,6 +82,11 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
         )
         self.log.info("Response Body: ", self.data_pipeline)
 
+        if "error" in self.response:
+            raise AirflowException(
+                print(self.data_pipeline.get("error").get("message"))
+            )
+
         # returns the full response body
         return self.data_pipeline
 
@@ -135,5 +140,10 @@ class RunDataPipelineOperator(GoogleCloudBaseOperator):
             project_id = self.project_id,
             location = self.location,
         )
+
+        if "error" in self.response:
+            raise AirflowException(
+                print(self.response.get("error").get("message"))
+            )
 
         return self.response


### PR DESCRIPTION
If the hook call results in an error, it will return an error dictionary containing the error details and message. Example:
{
  "error": {
    "code": int,
    "message": "string",
    "status": "string",
    "details": [
      {
        "@type": "string",
        "detail": "string"
      }
    ]
  }
}

Raise AirflowException with the error message value. 