### PR TITLE
Test run operator execute; start hook tests

### DIFF
--- a/tests/providers/google/cloud/hooks/test_datapipeline.py
+++ b/tests/providers/google/cloud/hooks/test_datapipeline.py
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import copy
+import re
+import shlex
+from asyncio import Future
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.providers.google.cloud.hooks.datapipeline import DataPipelineHook
+
+TASK_ID = "test-data_pipeline-operator"
+TEST_BODY = {
+    "name": "projects/dataflow-interns/locations/us-central1/pipelines/dp-create-1642676351302-mp--1675461000",
+            "type": "PIPELINE_TYPE_BATCH",
+            "workload": {
+                "dataflowFlexTemplateRequest": {
+                "launchParameter": {
+                    "containerSpecGcsPath": "gs://intern-bucket-1/templates/word-count.json",
+                    "jobName": "word-count-test-intern1",
+                    "environment": {
+                    "tempLocation": "gs://intern-bucket-1/temp"
+                    },
+                    "parameters": {
+                    "inputFile": "gs://intern-bucket-1/examples/kinglear.txt",
+                    "output": "gs://intern-bucket-1/results/hello"
+                    }
+                },
+                "projectId": "dataflow-interns",
+                "location": "us-central1"
+                }
+            }
+}
+TEST_LOCATION = "test-location"
+TEST_PROJECTID = "test-project-id"
+TEST_GCP_CONN_ID = "test_gcp_conn_id"
+TEST_DATA_PIPELINE_NAME = "test_data_pipeline_name"
+
+class TestDataPipelineHook:
+    def setup_method(self):
+        self.data_pipeline_hook = DataPipelineHook(gcp_conn_id="google-cloud-default")

--- a/tests/providers/google/cloud/operators/test_datapipeline.py
+++ b/tests/providers/google/cloud/operators/test_datapipeline.py
@@ -56,6 +56,7 @@ TEST_BODY = {
 TEST_LOCATION = "test-location"
 TEST_PROJECTID = "test-project-id"
 TEST_GCP_CONN_ID = "test_gcp_conn_id"
+TEST_DATA_PIPELINE_NAME = "test_data_pipeline_name"
 
 class TestCreateDataPipelineOperator:
     @pytest.fixture
@@ -70,3 +71,33 @@ class TestCreateDataPipelineOperator:
     # TODO: Test the execute function 
     # TODO: Test Hook
     # TODO: Test all parameters are given
+
+class TestRunDataPipelineOperator:
+    @pytest.fixture
+    def run_operator(self):
+        """Create a RunDataPipelineOperator instance"""
+        return RunDataPipelineOperator(
+            task_id=TASK_ID,
+            data_pipeline_name=TEST_DATA_PIPELINE_NAME,
+            project_id=TEST_PROJECTID,
+            location=TEST_LOCATION,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.operators.datapipeline.DataPipelineHook")
+    def test_execute(self, data_pipeline_hook_mock, run_operator):
+        run_pipeline_hook = data_pipeline_hook_mock.return_value.run_data_pipeline
+        run_operator.execute()
+        data_pipeline_hook_mock.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=None,
+        )
+        
+        run_pipeline_hook.assert_called_once_with(
+            data_pipeline_name=TEST_DATA_PIPELINE_NAME,
+            project_id=TEST_PROJECTID,
+            location=TEST_LOCATION,
+        )
+
+    # TODO write test with correct params
+    # TODO write test with wrong params

--- a/tests/providers/google/cloud/operators/test_datapipeline.py
+++ b/tests/providers/google/cloud/operators/test_datapipeline.py
@@ -28,7 +28,6 @@ from airflow.providers.google.cloud.operators.datapipeline import (
     CreateDataPipelineOperator,
     RunDataPipelineOperator,
 )
-from airflow.providers.google.cloud.hooks.datapipeline import DataPipelineHook
 from airflow.version import version
 
 TASK_ID = "test-datapipeline-operators"
@@ -86,18 +85,17 @@ class TestRunDataPipelineOperator:
 
     @mock.patch("airflow.providers.google.cloud.operators.datapipeline.DataPipelineHook")
     def test_execute(self, data_pipeline_hook_mock, run_operator):
-        run_pipeline_hook = data_pipeline_hook_mock.return_value.run_data_pipeline
-        run_operator.execute()
+        """Test Run Operator execute with correct parameters"""
+        run_operator.execute(mock.MagicMock())
         data_pipeline_hook_mock.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=None,
         )
         
-        run_pipeline_hook.assert_called_once_with(
+        data_pipeline_hook_mock.return_value.run_data_pipeline.assert_called_once_with(
             data_pipeline_name=TEST_DATA_PIPELINE_NAME,
             project_id=TEST_PROJECTID,
             location=TEST_LOCATION,
         )
 
-    # TODO write test with correct params
-    # TODO write test with wrong params
+    # TODO test execute errors


### PR DESCRIPTION
Create TestRunDataPipelineOperator class and test_execute function to test functionality of run operator execution with correct parameters given.

Removed line 31 - importing DataPipelineHook since we are using mock for the hooks