### PR TITLE
Add tests for run operator

### DIFF
--- a/tests/providers/google/cloud/operators/test_datapipeline.py
+++ b/tests/providers/google/cloud/operators/test_datapipeline.py
@@ -28,7 +28,6 @@ from airflow.providers.google.cloud.operators.datapipeline import (
     CreateDataPipelineOperator,
     RunDataPipelineOperator,
 )
-from airflow.providers.google.cloud.hooks.datapipeline import DataPipelineHook
 from airflow.version import version
 
 TASK_ID = "test-datapipeline-operators"

--- a/tests/providers/google/cloud/operators/test_datapipeline.py
+++ b/tests/providers/google/cloud/operators/test_datapipeline.py
@@ -173,7 +173,7 @@ class TestRunDataPipelineOperator:
             location=TEST_LOCATION,
         )
 
-    def test_valid_data_pipeline_name(self):
+    def test_data_pipeline_name_valid(self):
         """
         Test that AirflowException is raised if Run Operator is not given a data pipeline name.
         """
@@ -187,7 +187,7 @@ class TestRunDataPipelineOperator:
         with pytest.raises(AirflowException):
             RunDataPipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
-    def test_valid_project_id(self):
+    def test_project_id_valid(self):
         """
         Test that AirflowException is raised if Run Operator is not given a project ID.
         """
@@ -201,7 +201,7 @@ class TestRunDataPipelineOperator:
         with pytest.raises(AirflowException):
             RunDataPipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
-    def test_valid_location(self):
+    def test_location_valid(self):
         """
         Test that AirflowException is raised if Run Operator is not given a location.
         """
@@ -215,7 +215,7 @@ class TestRunDataPipelineOperator:
         with pytest.raises(AirflowException):
             RunDataPipelineOperator(**init_kwargs).execute(mock.MagicMock())
 
-    def test_valid_response(self):
+    def test_response_valid(self):
         """
         Test that AirflowException is raised if Run Operator fails execution and returns error.
         """

--- a/tests/providers/google/cloud/operators/test_datapipeline.py
+++ b/tests/providers/google/cloud/operators/test_datapipeline.py
@@ -143,3 +143,89 @@ class TestCreateDataPipelineOperator:
         }
         with pytest.raises(AirflowException):
             CreateDataPipelineOperator(**init_kwargs).execute(mock.MagicMock())
+
+class TestRunDataPipelineOperator:
+    @pytest.fixture
+    def run_operator(self):
+        """
+        Create a RunDataPipelineOperator instance with test data
+        """
+        return RunDataPipelineOperator(
+            task_id=TASK_ID,
+            data_pipeline_name=TEST_DATA_PIPELINE_NAME,
+            project_id=TEST_PROJECTID,
+            location=TEST_LOCATION,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.operators.datapipeline.DataPipelineHook")
+    def test_execute(self, data_pipeline_hook_mock, run_operator):
+        """
+        Test Run Operator execute with correct parameters
+        """
+        run_operator.execute(mock.MagicMock())
+        data_pipeline_hook_mock.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        
+        data_pipeline_hook_mock.return_value.run_data_pipeline.assert_called_once_with(
+            data_pipeline_name=TEST_DATA_PIPELINE_NAME,
+            project_id=TEST_PROJECTID,
+            location=TEST_LOCATION,
+        )
+
+    def test_valid_data_pipeline_name(self):
+        """
+        Test that AirflowException is raised if Run Operator is not given a data pipeline name.
+        """
+        init_kwargs = {
+            "task_id": TASK_ID,
+            "data_pipeline_name": None,
+            "project_id": TEST_PROJECTID,
+            "location": TEST_LOCATION,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+        }
+        with pytest.raises(AirflowException):
+            RunDataPipelineOperator(**init_kwargs).execute(mock.MagicMock())
+
+    def test_valid_project_id(self):
+        """
+        Test that AirflowException is raised if Run Operator is not given a project ID.
+        """
+        init_kwargs = {
+            "task_id": TASK_ID,
+            "data_pipeline_name": TEST_DATA_PIPELINE_NAME,
+            "project_id": None,
+            "location": TEST_LOCATION,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+        }
+        with pytest.raises(AirflowException):
+            RunDataPipelineOperator(**init_kwargs).execute(mock.MagicMock())
+
+    def test_valid_location(self):
+        """
+        Test that AirflowException is raised if Run Operator is not given a location.
+        """
+        init_kwargs = {
+            "task_id": TASK_ID,
+            "data_pipeline_name": TEST_DATA_PIPELINE_NAME,
+            "project_id": TEST_PROJECTID,
+            "location": None,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+        }
+        with pytest.raises(AirflowException):
+            RunDataPipelineOperator(**init_kwargs).execute(mock.MagicMock())
+
+    def test_valid_response(self):
+        """
+        Test that AirflowException is raised if Run Operator fails execution and returns error.
+        """
+        init_kwargs = {
+            "task_id": TASK_ID,
+            "data_pipeline_name": TEST_DATA_PIPELINE_NAME,
+            "project_id": TEST_PROJECTID,
+            "location": TEST_LOCATION,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+        }
+        with pytest.raises(AirflowException):
+            RunDataPipelineOperator(**init_kwargs).execute(mock.MagicMock()).return_value = {"error":{"message":"example error"}}


### PR DESCRIPTION
Unit tests for RunDataPipelineOperator. Testing the execute function and that the AirflowExceptions are raised correctly.

Removed import of the DataPipelineHook as we are using mocks for the hooks, not calling the real object.