### PR TITLE
Re: manavgarg, address PR comments on wording

### DIFF
--- a/airflow/providers/google/cloud/hooks/datapipeline.py
+++ b/airflow/providers/google/cloud/hooks/datapipeline.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module contains a Google DataPipeline Hook."""
+"""This module contains a Google Data Pipelines Hook."""
 from __future__ import annotations
 
 import functools
@@ -61,7 +61,7 @@ class DataPipelineHook(GoogleBaseHook):
         )
 
     def get_conn(self) -> build:
-        """Returns a Google Cloud DataPipeline service object."""
+        """Returns a Google Cloud Data Pipelines service object."""
         http_authorized = self._authorize()
         return build("datapipelines", "v1", http=http_authorized, cache_discovery=False)
 
@@ -78,7 +78,7 @@ class DataPipelineHook(GoogleBaseHook):
         :param body: The request body (contains instance of Pipeline). See:
             https://cloud.google.com/dataflow/docs/reference/data-pipelines/rest/v1/projects.locations.pipelines/create#request-body
         :param project_id: The ID of the GCP project that owns the job.
-        :param location: The location to direct the Data Pipeline instance to (example_dags uses uscentral-1).
+        :param location: The location to direct the Data Pipelines instance to (example_dags uses uscentral-1).
         
         Returns the created Data Pipelines instance in JSON representation.
         """

--- a/airflow/providers/google/cloud/hooks/datapipeline.py
+++ b/airflow/providers/google/cloud/hooks/datapipeline.py
@@ -73,14 +73,14 @@ class DataPipelineHook(GoogleBaseHook):
         location: str = DEFAULT_DATAPIPELINE_LOCATION,
     ) -> None:
         """
-        Creates a new Data Pipeline instance from the Data Pipeline API.
+        Creates a new Data Pipelines instance from the Data Pipelines API.
 
         :param body: The request body (contains instance of Pipeline). See:
             https://cloud.google.com/dataflow/docs/reference/data-pipelines/rest/v1/projects.locations.pipelines/create#request-body
         :param project_id: The ID of the GCP project that owns the job.
         :param location: The location to direct the Data Pipeline instance to (example_dags uses uscentral-1).
         
-        Returns the created Pipeline instance in JSON representation.
+        Returns the created Data Pipelines instance in JSON representation.
         """
         
         parent = self.build_parent_name(project_id, location)
@@ -107,12 +107,12 @@ class DataPipelineHook(GoogleBaseHook):
         location: str = DEFAULT_DATAPIPELINE_LOCATION,
     ) -> None:
         """
-        Runs a Data Pipeline Instance using the Data Pipeline API 
+        Runs a Data Pipelines Instance using the Data Pipelines API 
 
         :param data_pipeline_name:  The display name of the pipeline. In example 
             projects/PROJECT_ID/locations/LOCATION_ID/pipelines/PIPELINE_ID it would be the PIPELINE_ID.
         :param project_id: The ID of the GCP project that owns the job.
-        :param location: The location of the Data Pipeline instance to (example_dags uses uscentral-1).
+        :param location: The location of the Data Pipelines instance to (example_dags uses uscentral-1).
         
         Returns the created Job in JSON representation.
         """

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -99,8 +99,7 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
             raise AirflowException(
                   self.data_pipeline.get("error").get("message")
             )
-        
-        # returns the full response body
+
         return self.data_pipeline
 
 

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module contains Google DataPipelines operators."""
+"""This module contains Google Data Pipelines operators."""
 from __future__ import annotations
 
 import copy

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module contains Google DataPipeline operators."""
+"""This module contains Google DataPipelines operators."""
 from __future__ import annotations
 
 import copy
@@ -41,7 +41,7 @@ from airflow.version import version
 
 class CreateDataPipelineOperator(GoogleCloudBaseOperator):
     """ 
-    Creates a new Data Pipeline instance from the Data Pipeline API.
+    Creates a new Data Pipelines instance from the Data Pipelines API.
 
     :param body: The request body (contains instance of Pipeline). See:
         https://cloud.google.com/dataflow/docs/reference/data-pipelines/rest/v1/projects.locations.pipelines/create#request-body
@@ -50,7 +50,7 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: The connection ID to connect to the Google Cloud
         Platform.
 
-    Returns the created Pipeline instance in JSON representation.
+    Returns the created Data Pipelines instance in JSON representation.
     """
     def __init__(
         self,
@@ -106,7 +106,7 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
 
 class RunDataPipelineOperator(GoogleCloudBaseOperator):
     """ 
-    Runs a Data Pipeline Instance using the Data Pipeline API 
+    Runs a Data Pipelines Instance using the Data Pipelines API 
 
     :param data_pipeline_name:  The display name of the pipeline. In example 
         projects/PROJECT_ID/locations/LOCATION_ID/pipelines/PIPELINE_ID it would be the PIPELINE_ID.

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -46,7 +46,7 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
     :param body: The request body (contains instance of Pipeline). See:
         https://cloud.google.com/dataflow/docs/reference/data-pipelines/rest/v1/projects.locations.pipelines/create#request-body
     :param project_id: The ID of the GCP project that owns the job.
-    :param location: The location to direct the Data Pipeline instance to (example_dags uses uscentral-1).
+    :param location: The location to direct the Data Pipelines instance to (example_dags uses uscentral-1).
     :param gcp_conn_id: The connection ID to connect to the Google Cloud
         Platform.
 
@@ -73,15 +73,15 @@ class CreateDataPipelineOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context):
         if self.body is None:
                 raise AirflowException(
-                    "Request Body not given; cannot create a DataPipeline without the Request Body."
+                    "Request Body not given; cannot create a Data Pipeline without the Request Body."
                 )
         if self.project_id is None:
                 raise AirflowException(
-                    "Project ID not given; cannot create a DataPipeline without the Project ID."
+                    "Project ID not given; cannot create a Data Pipeline without the Project ID."
                 )
         if self.location is None:
                 raise AirflowException(
-                    "location not given; cannot create a DataPipeline without the location."
+                    "location not given; cannot create a Data Pipeline without the location."
                 )
         
         self.datapipeline_hook = DataPipelineHook(
@@ -110,7 +110,7 @@ class RunDataPipelineOperator(GoogleCloudBaseOperator):
     :param data_pipeline_name:  The display name of the pipeline. In example 
         projects/PROJECT_ID/locations/LOCATION_ID/pipelines/PIPELINE_ID it would be the PIPELINE_ID.
     :param project_id: The ID of the GCP project that owns the job.
-    :param location: The location of the Data Pipeline instance to (example_dags uses uscentral-1).
+    :param location: The location of the Data Pipelines instance to (example_dags uses uscentral-1).
     :param gcp_conn_id: The connection ID to connect to the Google Cloud
         Platform.
 
@@ -140,11 +140,11 @@ class RunDataPipelineOperator(GoogleCloudBaseOperator):
             )
         if self.project_id is None:
             raise AirflowException(
-                "Project ID not given; cannot run pipeline."
+                "Data Pipeline Project ID not given; cannot run pipeline."
             )
         if self.location is None:
             raise AirflowException(
-                "Pipeline location not given; cannot run pipeline."
+                "Data Pipeline location not given; cannot run pipeline."
             )
 
         self.response = self.data_pipeline_hook.run_data_pipeline(


### PR DESCRIPTION
The official name is Google Data Pipelines, instead of Google Data Pipeline; adjust wording throughout comments to match this.
